### PR TITLE
Fix violations of Sonar rule 2184

### DIFF
--- a/src/java/com/verificatum/protocol/demo/Demo.java
+++ b/src/java/com/verificatum/protocol/demo/Demo.java
@@ -293,7 +293,7 @@ public class Demo {
         // Keep the demo window open if requested.
         if (!opt.getBooleanValue("-hide") && opt.valueIsGiven("-keep")) {
             final int seconds = opt.getIntValue("-keep");
-            Thread.sleep(1000 * seconds);
+            Thread.sleep(1000l * seconds);
         }
 
         // Destroy the windows.


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar rule 2184: "Math operands should be cast before assignment"](https://rules.sonarsource.com/java/RSPEC-2184).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2184](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#math-operands-should-be-cast-before-assignment-sonar-rule-2184).
