### PR TITLE
Fix violations of Sonar rule 2095

### DIFF
--- a/VerificatumTool.java
+++ b/VerificatumTool.java
@@ -78,15 +78,15 @@ public final class VerificatumTool {
     private static void formatParagraph(final StringBuilder sb,
                                         final String command,
                                         final String description) {
-        final Formatter f = new Formatter(sb, Locale.US);
-
-        final String broken = Util.breakLines(description, Opt.LINE_WIDTH - 8);
-        final String[] lines = Util.split(broken, "\n");
-        f.format(" %-4s - %s", command, lines[0]);
-        for (int i = 1; i < lines.length; i++) {
-            f.format("%n%5s   %s", "", lines[i]);
+        try (final Formatter f = new Formatter(sb, Locale.US)) {
+            final String broken = Util.breakLines(description, Opt.LINE_WIDTH - 8);
+            final String[] lines = Util.split(broken, "\n");
+            f.format(" %-4s - %s", command, lines[0]);
+            for (int i = 1; i < lines.length; i++) {
+                f.format("%n%5s   %s", "", lines[i]);
+            }
+            sb.append('\n');
         }
-        sb.append('\n');
     }
 
     /**

--- a/src/java/com/verificatum/vmn/VMNTool.java
+++ b/src/java/com/verificatum/vmn/VMNTool.java
@@ -79,15 +79,15 @@ public final class VMNTool {
     private static void formatParagraph(final StringBuilder sb,
                                         final String command,
                                         final String description) {
-        final Formatter f = new Formatter(sb, Locale.US);
-
-        final String broken = Util.breakLines(description, Opt.LINE_WIDTH - 8);
-        final String[] lines = Util.split(broken, "\n");
-        f.format(" %-4s - %s", command, lines[0]);
-        for (int i = 1; i < lines.length; i++) {
-            f.format("%n%5s   %s", "", lines[i]);
+        try (final Formatter f = new Formatter(sb, Locale.US)) {
+            final String broken = Util.breakLines(description, Opt.LINE_WIDTH - 8);
+            final String[] lines = Util.split(broken, "\n");
+            f.format(" %-4s - %s", command, lines[0]);
+            for (int i = 1; i < lines.length; i++) {
+                f.format("%n%5s   %s", "", lines[i]);
+            }
+            sb.append('\n');
         }
-        sb.append('\n');
     }
 
     /**


### PR DESCRIPTION
Hi,

This PR fixes 2 violations of [Sonar Rule 2095: 'Resources should be closed'](https://rules.sonarsource.com/java/RSPEC-2095).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2095](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#resources-should-be-closed-sonar-rule-2095).