### PR TITLE
Fix violations of Sonar rule 2142

### DIFF
--- a/src/java/com/verificatum/protocol/hvzk/CCPoSW.java
+++ b/src/java/com/verificatum/protocol/hvzk/CCPoSW.java
@@ -152,6 +152,7 @@ public final class CCPoSW extends ProtocolElGamal implements CCPoS {
             try {
                 commitmentExportThread.join();
             } catch (final InterruptedException ie) {
+                Thread.currentThread().interrupt();
             }
         }
     }
@@ -256,6 +257,7 @@ public final class CCPoSW extends ProtocolElGamal implements CCPoS {
             try {
                 commitmentExportThread.join();
             } catch (final InterruptedException ie) {
+                Thread.currentThread().interrupt();
             }
         }
 

--- a/src/java/com/verificatum/protocol/mixnet/ShufflerElGamalSession.java
+++ b/src/java/com/verificatum/protocol/mixnet/ShufflerElGamalSession.java
@@ -938,6 +938,7 @@ public final class ShufflerElGamalSession extends ProtocolElGamal {
             try {
                 nextOutputThread.join();
             } catch (final InterruptedException ie) {
+                Thread.currentThread().interrupt();
                 throw new ProtocolError("Unable to join threads!", ie);
             }
             nextOutputThread = null;


### PR DESCRIPTION
Hi,

This PR fixes 3 violations of [Sonar Rule 2142: '"InterruptedException" should not be ignored'](https://rules.sonarsource.com/java/RSPEC-2142).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2142](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#interruptedexception-should-not-be-ignored-sonar-rule-2142).
