### PR TITLE
Fix violations of Sonar rule 1854

### DIFF
--- a/src/java/com/verificatum/protocol/distr/IndependentGeneratorsI.java
+++ b/src/java/com/verificatum/protocol/distr/IndependentGeneratorsI.java
@@ -238,7 +238,6 @@ public final class IndependentGeneratorsI extends ProtocolElGamal
 
         // Collect generators parts.
         tempLog.info("Collect generators parts.");
-        Log tempLog2 = tempLog.newChildLog();
 
         // Publish our parts and read the other's.
         publishAndReadParts(pGroup, generatorsParts, size, threshold, log);
@@ -262,7 +261,7 @@ public final class IndependentGeneratorsI extends ProtocolElGamal
 
         // Generate seed for batching.
         tempLog.info("Generate seed for batching.");
-        tempLog2 = tempLog.newChildLog();
+        Log tempLog2 = tempLog.newChildLog();
 
         final byte[] prgSeed =
             coins.getCoinBytes(tempLog2, 8 * prg.minNoSeedBytes(), rbitlen);
@@ -270,7 +269,6 @@ public final class IndependentGeneratorsI extends ProtocolElGamal
 
         // Collect commitments.
         tempLog.info("Collect commitments.");
-        tempLog2 = tempLog.newChildLog();
 
         // Publish our parts and read the other's.
         publishAndSetCommitments(basic, threshold, log);

--- a/src/java/com/verificatum/protocol/elgamal/DistrElGamalSession.java
+++ b/src/java/com/verificatum/protocol/elgamal/DistrElGamalSession.java
@@ -531,7 +531,6 @@ public final class DistrElGamalSession extends ProtocolElGamal {
         for (int l = 1; l <= k; l++) {
             decryptionFactors[l].free();
         }
-        decryptionFactors = null;
 
         tempLog.info("Compute plaintexts.");
         final PGroupElementArray plaintexts =

--- a/src/java/com/verificatum/protocol/elgamal/ProtocolElGamal.java
+++ b/src/java/com/verificatum/protocol/elgamal/ProtocolElGamal.java
@@ -815,13 +815,11 @@ public class ProtocolElGamal extends ProtocolBBT {
         plainKeys.generate(tempLog);
         pkeys = plainKeys.getPKeys();
         skey = plainKeys.getSKey();
-        plainKeys = null;
 
         // Generate an "independent" generator.
         IndependentGenerator ig =
             new IndependentGenerator("", this, pGroup, pkeys, skey, rbitlen);
         final PGroupElement h = ig.generate(tempLog);
-        ig = null;
 
         // Construct a source of jointly generated random coins.
         coins = new CoinFlipPRingSource("", this, h, pkeys, skey, rbitlen);

--- a/src/java/com/verificatum/protocol/mixnet/MixNetElGamalTool.java
+++ b/src/java/com/verificatum/protocol/mixnet/MixNetElGamalTool.java
@@ -1025,8 +1025,6 @@ public final class MixNetElGamalTool {
             System.err.println("Missing parent PID!");
             System.exit(1);
         }
-
-        final String parentPidString = args[0];
         final String[] newargs = Arrays.copyOfRange(args, 1, args.length);
 
         // Simple textual user interface.
@@ -1085,11 +1083,6 @@ public final class MixNetElGamalTool {
                 processSetpk(mixnet, opt);
                 return;
             }
-
-            // Create PID file. Everything from now on are protocol
-            // executions in contrast to the operations above that are
-            // local operations.
-            final File pidFile = new File(mixnet.getDirectory(), "pidfile");
             // try {
             //     new PID(parentPidString, pidFile);
             // } catch (UtilException ue) {

--- a/src/java/com/verificatum/protocol/mixnet/ShufflerElGamalSession.java
+++ b/src/java/com/verificatum/protocol/mixnet/ShufflerElGamalSession.java
@@ -941,7 +941,6 @@ public final class ShufflerElGamalSession extends ProtocolElGamal {
                 Thread.currentThread().interrupt();
                 throw new ProtocolError("Unable to join threads!", ie);
             }
-            nextOutputThread = null;
         }
 
         // If the proof was rejected, then we need to drop our


### PR DESCRIPTION
Hi,

This PR fixes 8 violations of [Sonar Rule 1854: 'Unused assignments should be removed'](https://rules.sonarsource.com/java/RSPEC-1854).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 1854](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#unused-assignments-should-be-removed-sonar-rule-1854).